### PR TITLE
agregar filtro por errorSignature y corregir filtro de fecha

### DIFF
--- a/controllers/logController.js
+++ b/controllers/logController.js
@@ -23,7 +23,15 @@ const getAllLogs = async (req, res) => {
         const sortBy = req.query.sortBy || 'last_seen_at';
         const sortOrder = req.query.sortOrder || 'desc';
 
-        // Pasar los filtros de fecha al servicio
+        let dateFilter = req.query.date;
+        if (dateFilter) {
+            const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+            if (!dateRegex.test(dateFilter)) {
+                return res.status(400).json({ msg: 'Invalid date format. Use YYYY-MM-DD.' });
+            }
+        }
+
+        // Pasar todos los filtros al servicio
         const filters = {
             search: req.query.search,
             issue_id: req.query.issue_id,
@@ -31,14 +39,14 @@ const getAllLogs = async (req, res) => {
             description: req.query.description,
             culprit: req.query.culprit,
             error_type: req.query.error_type,
+            error_signature: req.query.error_signature,
             environment: req.query.environment,
             status: req.query.status,
             priority: req.query.priority,
             assigned_to: req.query.assigned_to,
             active: req.query.active,
             hash: req.query.hash,
-            startDate: req.query.startDate,
-            endDate: req.query.endDate
+            date: req.query.date
         };
 
 

--- a/docs/log.docs.js
+++ b/docs/log.docs.js
@@ -130,23 +130,16 @@
  *           type: string
  *         description: Identificador único generado por culprit, error_type, y environment
  *       - in: query
- *         name: startDate
+ *         name: error_signature
  *         schema:
  *           type: string
- *           format: date-time
- *         description: "Filtrar logs creados después de esta fecha (formato: YYYY-MM-DD)"
+ *         description: Filtrar por firma de error
  *       - in: query
- *         name: endDate
+ *         name: date
  *         schema:
  *           type: string
- *           format: date-time
- *         description: "Filtrar logs creados antes de esta fecha (formato: YYYY-MM-DD)"
- *       - in: query
- *         name: sortBy
- *         schema:
- *           type: string
- *           default: last_seen_at
- *         description: "Campo por el cual ordenar [ej: created_at, last_seen_at]"
+ *           format: date
+ *         description: "Filtrar logs por fecha específica (formato: YYYY-MM-DD)"
  *       - in: query
  *         name: sortOrder
  *         schema:

--- a/services/logService.js
+++ b/services/logService.js
@@ -16,6 +16,7 @@ const getAllLogs = async (filters, pagination) => {
       { description: { $regex: filters.search, $options: "i" } },
       { culprit: { $regex: filters.search, $options: "i" } },
       { error_type: { $regex: filters.search, $options: "i" } },
+      { error_signature: { $regex: filters.search, $options: "i" } },
       { environment: { $regex: filters.search, $options: "i" } },
       { status: { $regex: filters.search, $options: "i" } },
       { priority: { $regex: filters.search, $options: "i" } },
@@ -34,6 +35,7 @@ const getAllLogs = async (filters, pagination) => {
     "description",
     "culprit",
     "error_type",
+    "error_signature",
     "environment",
     "status",
     "priority",
@@ -49,15 +51,15 @@ const getAllLogs = async (filters, pagination) => {
   });
 
   // Filtros de fecha
-  if (filters.startDate || filters.endDate) {
-    const dateQuery = {};
-    if (filters.startDate) {
-      dateQuery.$gte = new Date(filters.startDate);
-    }
-    if (filters.endDate) {
-      dateQuery.$lte = new Date(filters.endDate);
-    }
-    query.created_at = dateQuery;
+  if (filters.date) {
+    const date = new Date(filters.date + 'T00:00:00.000Z');
+    const nextDay = new Date(date);
+    nextDay.setDate(nextDay.getDate() + 1);
+
+    query.created_at = {
+      $gte: date,
+      $lt: nextDay
+    };
   }
 
   // Ordenamiento
@@ -79,6 +81,7 @@ const getAllLogs = async (filters, pagination) => {
       description: log.description,
       culprit: log.culprit,
       error_type: log.error_type,
+      error_signature: log.error_signature,
       environment: log.environment,
       status: log.status,
       priority: log.priority,
@@ -106,6 +109,7 @@ const getLogById = async (id) => {
     description: log.description,
     culprit: log.culprit,
     error_type: log.error_type,
+    error_signature: log.error_signature,
     environment: log.environment,
     status: log.status,
     priority: log.priority,


### PR DESCRIPTION
- Se agregó la capacidad de filtrar logs por el campo errorSignature.
- Se corrigió el filtro de fecha para que funcione correctamente.
- Se validó el formato de la fecha (YYYY-MM-DD) en el controlador para evitar errores por formatos incorrectos.